### PR TITLE
Us4/merchant coupon deactivate

### DIFF
--- a/app/controllers/coupons_controller.rb
+++ b/app/controllers/coupons_controller.rb
@@ -4,6 +4,7 @@ class CouponsController < ApplicationController
   end
 
   def show
+    @merchant = Merchant.find(params[:merchant_id])
     @coupon = Coupon.find(params[:id])
   end
 

--- a/app/controllers/coupons_controller.rb
+++ b/app/controllers/coupons_controller.rb
@@ -31,13 +31,24 @@ class CouponsController < ApplicationController
     else
       redirect_to new_merchant_coupon_path(@merchant)
       flash[:notice] = "Please complete all fields"
+    end
+  end
 
+  def update
+    @merchant = Merchant.find(params[:merchant_id])
+    @coupon = Coupon.find(params[:id])
+
+    if @merchant.five_active_coupons?
+      flash[:alert] = "Limit 5 active coupons. Please deactivate one before creating another"
+    else
+      @coupon.update(activated: false)
+      redirect_to merchant_coupon_path(@merchant, @coupon)
     end
   end
 
   private
 
   def coupon_params
-    params.require(:coupon).permit(:name, :code, :value, :value_type, :merchant_id)
+    params.require(:coupon).permit(:name, :code, :value, :value_type, :merchant_id, :activated)
   end
 end

--- a/app/views/coupons/show.html.erb
+++ b/app/views/coupons/show.html.erb
@@ -5,3 +5,5 @@
 <p>Value Type: <%= @coupon.value_type %></p>
 <p>Coupon Activated?: <%= @coupon.activated %></p>
 <p>Times Used: <%= @coupon.times_used %></p>
+
+<%= button_to "Deactivate #{@coupon.name}", merchant_coupon_path(@merchant, @coupon), method: :patch, params: {activated: false} %>

--- a/spec/features/coupons/show_spec.rb
+++ b/spec/features/coupons/show_spec.rb
@@ -1,14 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe "Coupon's Show Page", type: :feature do
-  before(:each) do
-    @merch = Merchant.create!(name: "Jim Bob's")
-    @coupon1 = @merch.coupons.create!(name: "$10 off", code: "OFF10", value: 10.00, value_type: 1, activated: false)
-    @coupon2 = @merch.coupons.create!(name: "10% off", code: "TAKE10PER", value: 0.10, value_type: 0, activated: false)
-  end
-
+  
   describe "Merchant Coupon Index page links to show" do
     it "each name is a link that leads to that coupon's show page" do
+      @merch = Merchant.create!(name: "Jim Bob's")
+      @coupon1 = @merch.coupons.create!(name: "$10 off", code: "OFF10", value: 10.00, value_type: 1, activated: false)
+      @coupon2 = @merch.coupons.create!(name: "10% off", code: "TAKE10PER", value: 0.10, value_type: 0, activated: false)
       visit(merchant_coupons_path(@merch))
 
       within "#coupon_#{@coupon1.id}" do
@@ -34,14 +32,29 @@ RSpec.describe "Coupon's Show Page", type: :feature do
   describe "Coupon show page details" do
     it "shows coupon name, code, value, status, and number of times it's been used" do
       test_data
-      visit(merchant_coupon_path(@merch, @coupon2))
+      visit(merchant_coupon_path(@merchant1, @coupon1))
+      
+      expect(page).to have_content("#{@coupon1.name} Show Page")
+      expect(page).to have_content("Code: #{@coupon1.code}")
+      expect(page).to have_content("Value: #{@coupon1.value}")
+      expect(page).to have_content("Value Type: #{@coupon1.value_type}")
+      expect(page).to have_content("Coupon Activated?: #{@coupon1.activated}")
+      expect(page).to have_content("Times Used: #{@coupon1.times_used}")
+    end
+  end
+  
+  describe "Deactivate coupon button" do
+    it "has a button to deactivate a coupon" do
+      test_data
+      visit(merchant_coupon_path(@merchant1, @coupon1))
 
-      expect(page).to have_content("#{@coupon2.name} Show Page")
-      expect(page).to have_content("Code: #{@coupon2.code}")
-      expect(page).to have_content("Value: #{@coupon2.value}")
-      expect(page).to have_content("Value Type: #{@coupon2.value_type}")
-      expect(page).to have_content("Coupon Activated?: #{@coupon2.activated}")
-      expect(page).to have_content("Times Used: #{@coupon2.times_used}")
+      expect(page).to have_content("Coupon Activated?: true")
+      expect(page).to have_button("Deactivate #{@coupon1.name}")
+
+      click_button("Deactivate #{@coupon1.name}")
+
+      expect(current_path).to eq(merchant_coupon_path(@merchant1, @coupon1))
+      expect(page).to have_content("Coupon Activated?: false")
     end
   end
 end


### PR DESCRIPTION
PR contains the work for user story 4.
- Added a button to the coupon show page that allows a merchant to deactivate a coupon
- Added update action to coupons controller
- Adjusted routes as needed
- Will all get demolished and refactored with the next user story.
