### PR TITLE
Us5/merchant coupon activate

### DIFF
--- a/app/controllers/coupons_controller.rb
+++ b/app/controllers/coupons_controller.rb
@@ -40,8 +40,13 @@ class CouponsController < ApplicationController
 
     if @merchant.five_active_coupons?
       flash[:alert] = "Limit 5 active coupons. Please deactivate one before creating another"
-    else
+    elsif
+      @coupon.activated == true
       @coupon.update(activated: false)
+      redirect_to merchant_coupon_path(@merchant, @coupon)
+    else
+      @coupon.activated == false
+      @coupon.update(activated: true)
       redirect_to merchant_coupon_path(@merchant, @coupon)
     end
   end

--- a/app/views/coupons/show.html.erb
+++ b/app/views/coupons/show.html.erb
@@ -6,4 +6,8 @@
 <p>Coupon Activated?: <%= @coupon.activated %></p>
 <p>Times Used: <%= @coupon.times_used %></p>
 
-<%= button_to "Deactivate #{@coupon.name}", merchant_coupon_path(@merchant, @coupon), method: :patch, params: {activated: false} %>
+<% if @coupon.activated == true %>
+  <%= button_to "Deactivate #{@coupon.name}", merchant_coupon_path(@merchant, @coupon), method: :patch, params: {activated: false} %>
+<% else %>
+  <%= button_to "Activate #{@coupon.name}", merchant_coupon_path(@merchant, @coupon), method: :patch, params: {activated: true} %>
+<% end %>

--- a/spec/features/coupons/show_spec.rb
+++ b/spec/features/coupons/show_spec.rb
@@ -57,4 +57,19 @@ RSpec.describe "Coupon's Show Page", type: :feature do
       expect(page).to have_content("Coupon Activated?: false")
     end
   end
+
+  describe "Activate coupon button" do
+    it "has a button to activate a coupon" do
+      test_data
+      visit(merchant_coupon_path(@merchant1, @coupon3))
+
+      expect(page).to have_content("Coupon Activated?: false")
+      expect(page).to have_button("Activate #{@coupon3.name}")
+
+      click_button("Activate #{@coupon3.name}")
+
+      expect(current_path).to eq(merchant_coupon_path(@merchant1, @coupon3))
+      expect(page).to have_content("Coupon Activated?: true")
+    end
+  end
 end

--- a/spec/features/coupons/show_spec.rb
+++ b/spec/features/coupons/show_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Coupon's Show Page", type: :feature do
     it "has a button to deactivate a coupon" do
       test_data
       visit(merchant_coupon_path(@merchant1, @coupon1))
-
+# save_and_open_page
       expect(page).to have_content("Coupon Activated?: true")
       expect(page).to have_button("Deactivate #{@coupon1.name}")
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,7 @@ def test_data
 
   @coupon1 = @merchant1.coupons.create!(name: "Test $10", code: "TEST10", value: 10.00, value_type: 1, activated: true)
   @coupon2 = @merchant2.coupons.create!(name: "Test 10%", code: "10TEST", value: 0.10, value_type: 0, activated: true)
+  @coupon3 = @merchant1.coupons.create!(name: "Test $10", code: "20TEST", value: 20.00, value_type: 1, activated: false)
 
   @item_1 = @merchant1.items.create!(name: "Shampoo", description: "This washes your hair", unit_price: 100)
   @item_2 = @merchant1.items.create!(name: "Conditioner", description: "This makes your hair shiny", unit_price: 100)


### PR DESCRIPTION
This PR contains the work for user story 5.
- Conditional "activated" buttons added to coupon show page
- Update action in coupon controller needed the params specified instead of using the "coupon_params" helper method.
- Action can use some refactoring in the future if I have time