### PR TITLE
Us7/merchant invoice show page subtotal grand total revenues

### DIFF
--- a/app/controllers/coupons_controller.rb
+++ b/app/controllers/coupons_controller.rb
@@ -39,7 +39,8 @@ class CouponsController < ApplicationController
     @coupon = Coupon.find(params[:id])
 
     if @merchant.five_active_coupons?
-      flash[:alert] = "Limit 5 active coupons. Please deactivate one before creating another"
+      flash[:alert] = "Limit 5 active coupons. Please deactivate one before activating another"
+      redirect_to merchant_coupon_path(@merchant, @coupon)
     elsif
       @coupon.activated == true
       @coupon.update(activated: false)

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -16,6 +16,10 @@ class Invoice < ApplicationRecord
   end
 
   def rev_with_discount
-    
+    subtotal = total_revenue
+    if coupon.present?
+      discount = coupon_discount(subtotal)
+      subtotal - discount
+    end
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -20,6 +20,16 @@ class Invoice < ApplicationRecord
     if coupon.present?
       discount = coupon_discount(subtotal)
       subtotal - discount
+    else
+      subtotal
+    end
+  end
+
+  def coupon_discount(subtotal)
+    if coupon.value_type == 'percent'
+      subtotal * (coupon.value / 100)
+    else
+      coupon.value
     end
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -14,4 +14,8 @@ class Invoice < ApplicationRecord
   def total_revenue
     invoice_items.sum("unit_price * quantity")
   end
+
+  def rev_with_discount
+    
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -20,14 +20,12 @@ class Invoice < ApplicationRecord
     if coupon.present?
       discount = coupon_discount(subtotal)
       subtotal - discount
-    else
-      subtotal
     end
   end
 
   def coupon_discount(subtotal)
     if coupon.value_type == 'percent'
-      subtotal * (coupon.value / 100)
+      coupon.value * subtotal
     else
       coupon.value
     end

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -11,7 +11,8 @@
   <br>
 
   <p> Created on: <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></p>
-  <p>Total Revenue: <%= @invoice.total_revenue %></p>
+  <p> Subtotal: <%= number_to_currency(@invoice.total_revenue) %></p>
+  <p> Grand Total: <%= number_to_currency(@invoice.rev_with_discount) %></p>
 
 
   <h4>Customer:</h4>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -11,9 +11,15 @@
   <br>
 
   <p> Created on: <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></p>
-  <p> Subtotal: <%= number_to_currency(@invoice.total_revenue) %></p>
-  <p> Grand Total: <%= number_to_currency(@invoice.rev_with_discount) %></p>
-
+  <div id="coupon_area">
+    <p> Subtotal: <%= number_to_currency(@invoice.total_revenue) %></p>
+    <p> Grand Total: <%= number_to_currency(@invoice.rev_with_discount) %></p>
+    <% if @invoice.coupon.present? %>
+      <p>Coupon Used:</p>
+      <p> Name: <%= link_to @invoice.coupon.name, merchant_coupon_path(@merchant, @invoice.coupon) %> </p>
+      <p> Coupon Code: <%= @invoice.coupon.code %></p>
+    <% end %>
+  </div>
 
   <h4>Customer:</h4>
     <%= @customer.first_name %> <%= @customer.last_name %><br>

--- a/spec/features/coupons/show_spec.rb
+++ b/spec/features/coupons/show_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Coupon's Show Page", type: :feature do
     it "has a button to deactivate a coupon" do
       test_data
       visit(merchant_coupon_path(@merchant1, @coupon1))
-# save_and_open_page
+
       expect(page).to have_content("Coupon Activated?: true")
       expect(page).to have_button("Deactivate #{@coupon1.name}")
 
@@ -70,6 +70,25 @@ RSpec.describe "Coupon's Show Page", type: :feature do
 
       expect(current_path).to eq(merchant_coupon_path(@merchant1, @coupon3))
       expect(page).to have_content("Coupon Activated?: true")
+    end
+  end
+  
+  describe "Sad path to prevent coupon activation if there are 5 active coupons" do
+    it "will flash a message when trying to activate a sixth coupon" do
+      @merchant1 = Merchant.create!(name: "Hair Care")
+      @coupon1 = @merchant1.coupons.create!(name: "$10 off", code: "OFF10", value: 10.00, value_type: 1, activated: true)
+      @coupon2 = @merchant1.coupons.create!(name: "10% off", code: "TAKE10PER", value: 0.10, value_type: 0, activated: true)
+      @coupon3 = @merchant1.coupons.create!(name: "Summer Sale", code: "SUMMER", value: 0.25, value_type: 0, activated: true)
+      @coupon4 = @merchant1.coupons.create!(name: "Spring Sale", code: "SPRING", value: 25.00, value_type: 1, activated: true)
+      @coupon5 = @merchant1.coupons.create!(name: "Number 5", code: "NUM5", value: 5.00, value_type: 1, activated: true)
+      @coupon6 = @merchant1.coupons.create!(name: "Golden Ticket", code: "GOLDEN", value: 50.00, value_type: 1, activated: false)
+      
+      visit(merchant_coupon_path(@merchant1, @coupon6))
+      click_button("Activate #{@coupon6.name}")
+      
+      expect(current_path).to eq(merchant_coupon_path(@merchant1, @coupon6))
+      expect(page).to have_button("Activate #{@coupon6.name}")
+      expect(page).to have_content("Limit 5 active coupons. Please deactivate one before activating another")
     end
   end
 end

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -100,4 +100,14 @@ RSpec.describe "invoices show" do
     end
   end
 
+# US 7
+  it "displays the total revenue without coupon discount" do
+    visit(merchant_invoice_path(@merchant1, @invoice_1))
+    expect(page).to have_content(@invoice_1.total_revenue)
+  end
+  
+  it "displays the 'grand total' with coupon discount" do
+    visit(merchant_invoice_path(@merchant1, @invoice_1))
+    expect(page).to have_content(@invoice_1.rev_with_discount)
+  end
 end

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -103,13 +103,29 @@ RSpec.describe "invoices show" do
 # US 7
   it "displays the total revenue without coupon discount" do
     visit(merchant_invoice_path(@merchant1, @invoice_1))
-    expect(page).to have_content("Subtotal:")
-    expect(page).to have_content(@invoice_1.total_revenue)
+    within "#coupon_area" do
+      expect(page).to have_content("Subtotal:")
+      expect(page).to have_content(@invoice_1.total_revenue)
+    end
   end
   
   it "displays the 'grand total' with coupon discount" do
     visit(merchant_invoice_path(@merchant1, @invoice_1))
-    expect(page).to have_content("Grand Total:")
-    expect(page).to have_content(@invoice_1.rev_with_discount)
+    within "#coupon_area" do
+      expect(page).to have_content("Grand Total:")
+      expect(page).to have_content(@invoice_1.rev_with_discount)
+    end
+  end
+  
+  it "displays the name and code of coupon used as link to show page" do
+    test_data
+    visit(merchant_invoice_path(@merchant1, @invoice_1))
+    within "#coupon_area" do
+      expect(page).to have_content("Coupon Used:")
+      expect(page).to have_content("Name:")
+      expect(page).to have_content("Coupon Code:")
+      expect(page).to have_link(@coupon1.name)
+      expect(page).to have_content(@coupon1.code)
+    end
   end
 end

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -103,11 +103,13 @@ RSpec.describe "invoices show" do
 # US 7
   it "displays the total revenue without coupon discount" do
     visit(merchant_invoice_path(@merchant1, @invoice_1))
+    expect(page).to have_content("Subtotal:")
     expect(page).to have_content(@invoice_1.total_revenue)
   end
   
   it "displays the 'grand total' with coupon discount" do
     visit(merchant_invoice_path(@merchant1, @invoice_1))
+    expect(page).to have_content("Grand Total:")
     expect(page).to have_content(@invoice_1.rev_with_discount)
   end
 end

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -124,8 +124,11 @@ RSpec.describe "invoices show" do
       expect(page).to have_content("Coupon Used:")
       expect(page).to have_content("Name:")
       expect(page).to have_content("Coupon Code:")
-      expect(page).to have_link(@coupon1.name)
       expect(page).to have_content(@coupon1.code)
+      expect(page).to have_link(@coupon1.name)
+
+      click_link(@coupon1.name)
+      expect(current_path).to eq(merchant_coupon_path(@merchant1, @coupon1))
     end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -28,9 +28,11 @@ RSpec.describe Invoice, type: :model do
     it ".coupon_discount" do
       test_data
       expected1 = 10
+      subtotal1 = 900
       expected2 = 20
-      expect(@invoice_1.coupon_discount).to eq(expected1)
-      expect(@invoice_3.coupon_discount).to eq(expected2)
+      subtotal2 = 200
+      expect(@invoice_1.coupon_discount(subtotal1)).to eq(expected1)
+      expect(@invoice_3.coupon_discount(subtotal2)).to eq(expected2)
     end
 
     it ".rev_with_discount" do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -24,5 +24,11 @@ RSpec.describe Invoice, type: :model do
 
       expect(@invoice_1.total_revenue).to eq(100)
     end
+
+    it "rev_with_discount" do
+      test_data
+      expect(@invoice_1.rev_with_discount).to eq(890)
+      expect(@invoice_3.rev_with_discount).to eq(180)
+    end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe Invoice, type: :model do
 
     it ".coupon_discount" do
       test_data
-      expected1 = 10
-      subtotal1 = 900
-      expected2 = 20
-      subtotal2 = 200
+      expected1 = 10 # < invoice_1 discount
+      subtotal1 = 900 # <invoice_1 subtotal
+      expected2 = 20 # <invoice_3 discount 10% or 0.10
+      subtotal2 = 200 # <invoice_3 subtotal
       expect(@invoice_1.coupon_discount(subtotal1)).to eq(expected1)
       expect(@invoice_3.coupon_discount(subtotal2)).to eq(expected2)
     end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -25,7 +25,15 @@ RSpec.describe Invoice, type: :model do
       expect(@invoice_1.total_revenue).to eq(100)
     end
 
-    it "rev_with_discount" do
+    it ".coupon_discount" do
+      test_data
+      expected1 = 10
+      expected2 = 20
+      expect(@invoice_1.coupon_discount).to eq(expected1)
+      expect(@invoice_3.coupon_discount).to eq(expected2)
+    end
+
+    it ".rev_with_discount" do
       test_data
       expect(@invoice_1.rev_with_discount).to eq(890)
       expect(@invoice_3.rev_with_discount).to eq(180)


### PR DESCRIPTION
This PR contains the work for user story 7.
- Conditional coupon information added to invoice show page
- Revenue with discount method and coupon discount helper method defined in invoice model. Decided to place there since these are coupons that have to do with a particular invoice.
- All models tested to 100%
- Feature tests close behind
- Coupon name on invoice show page is a link that leads to that coupon's show page